### PR TITLE
feat:BaseTimeEntity 및 유저 권한 관련 엔티티 추가

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/ProfileImg/entity/ProfileImg.java
+++ b/src/main/java/com/korit/pawsmarket/domain/ProfileImg/entity/ProfileImg.java
@@ -1,0 +1,4 @@
+package com.korit.pawsmarket.domain.ProfileImg.entity;
+
+public class ProfileImg {
+}

--- a/src/main/java/com/korit/pawsmarket/domain/role/entity/Role.java
+++ b/src/main/java/com/korit/pawsmarket/domain/role/entity/Role.java
@@ -1,0 +1,26 @@
+package com.korit.pawsmarket.domain.role.entity;
+
+import com.korit.pawsmarket.domain.role.enums.Roletype;
+import com.korit.pawsmarket.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "role")
+public class Role extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "role_id")
+    private Long roleId;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "role_type")
+    private Roletype roleType;
+}

--- a/src/main/java/com/korit/pawsmarket/domain/role/entity/repository/RoleRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/role/entity/repository/RoleRepository.java
@@ -1,0 +1,4 @@
+package com.korit.pawsmarket.domain.role.entity.repository;
+
+public interface RoleRepository {
+}

--- a/src/main/java/com/korit/pawsmarket/domain/role/enums/Roletype.java
+++ b/src/main/java/com/korit/pawsmarket/domain/role/enums/Roletype.java
@@ -1,0 +1,6 @@
+package com.korit.pawsmarket.domain.role.enums;
+
+public enum Roletype {
+    USER,ADMIN
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/user/entity/User.java
+++ b/src/main/java/com/korit/pawsmarket/domain/user/entity/User.java
@@ -1,0 +1,45 @@
+package com.korit.pawsmarket.domain.user.entity;
+
+
+import com.korit.pawsmarket.domain.role.entity.Role;
+import com.korit.pawsmarket.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "user")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    private String email;
+
+    private String password;
+
+    private String nick;
+
+    private String address;
+
+    private LocalDateTime brith;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "role_id", nullable = false)
+    private Role role;
+
+
+
+
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/user/entity/repository/UserRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/user/entity/repository/UserRepository.java
@@ -1,0 +1,4 @@
+package com.korit.pawsmarket.domain.user.entity.repository;
+
+public interface UserRepository {
+}

--- a/src/main/java/com/korit/pawsmarket/global/entity/BaseEntity.java
+++ b/src/main/java/com/korit/pawsmarket/global/entity/BaseEntity.java
@@ -1,0 +1,51 @@
+package com.korit.pawsmarket.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "is_delete")
+    private boolean isDelete = false;
+
+    public void softDelete() {
+        isDelete = true;
+    }
+
+    // 날짜 포맷팅 메서드 추가
+    public String getFormattedCreatedAt() {
+        return formatDate(createdAt);
+    }
+
+    public String getFormattedUpdatedAt() {
+        return formatDate(updatedAt);
+    }
+
+    // 공통 날짜 포맷팅 로직
+    private String formatDate(LocalDateTime dateTime) {
+        if (dateTime != null) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+            return dateTime.format(formatter);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/jwt/filter/JwtFilter.java
+++ b/src/main/java/com/korit/pawsmarket/global/jwt/filter/JwtFilter.java
@@ -1,0 +1,4 @@
+package com.korit.pawsmarket.global.jwt.filter;
+
+public class JwtFilter {
+}

--- a/src/main/java/com/korit/pawsmarket/global/jwt/util/JwtUtil.java
+++ b/src/main/java/com/korit/pawsmarket/global/jwt/util/JwtUtil.java
@@ -1,0 +1,19 @@
+package com.korit.pawsmarket.global.jwt.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+
+@Slf4j
+@Component
+public class JwtUtil {
+   /* private final Key key;
+    private final long accessTokenExpTime;
+
+    public JwtUtil(
+
+    ){}*/
+
+
+}


### PR DESCRIPTION
## 📝 설명 (Description)  

BaseTimeEntity를 생성하고, 유저 및 권한 관련 엔티티를 추가했습니다.  
JPA Auditing을 활용하여 엔티티의 생성 및 수정 시간을 자동으로 관리하도록 설정하였습니다.  

---  

## 🔄 변경 사항 (Changes)  
이번 PR에서 수행된 변경 사항들을 정리해주세요:  

- [ ] BaseTimeEntity 생성 (createdAt, updatedAt 필드 추가)  
- [ ] User 엔티티 생성 (id, username, password, roles 필드 포함)  
- [ ] UserRole 엔티티 생성 (유저와 역할의 매핑)  
- [ ] Role 엔티티 생성 및 내부에 RoleType Enum 추가 (ADMIN, USER 등)  

---  

## 📌 참고 사항 (Additional Notes)  
- EnumType.STRING을 사용하여 RoleType Enum을 DB에 문자열로 저장하도록 설정했습니다.  
- 추후 Spring Security와 연계하여 권한 관리를 적용할 수 있습니다.  
