### PR TITLE
feat: 카테고리 엔티티 추가 및 생성 기능 구현, 응답 구조 설계

### DIFF
--- a/src/main/java/com/korit/pawsmarket/PawsMarketApplication.java
+++ b/src/main/java/com/korit/pawsmarket/PawsMarketApplication.java
@@ -2,8 +2,10 @@ package com.korit.pawsmarket;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class PawsMarketApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/korit/pawsmarket/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/controller/CategoryController.java
@@ -1,0 +1,36 @@
+package com.korit.pawsmarket.domain.category.controller;
+
+import com.korit.pawsmarket.domain.category.dto.req.CreateCategoryReqDto;
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
+import com.korit.pawsmarket.domain.category.facade.CategoryFacade;
+import com.korit.pawsmarket.global.response.ApiResponse;
+import com.korit.pawsmarket.global.response.enums.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Category", description = "카테고리 API")
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryFacade categoryFacade;
+
+    @Operation(summary = "카테고리 생성", description = "새로운 카테고리를 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createCategory(@Valid @RequestBody CreateCategoryReqDto reqDto) {
+
+        categoryFacade.createCategory(reqDto);
+
+        return ApiResponse.generateResp(Status.CREATE, "새로운 카테고리가 추가되었습니다.", null);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/dto/req/CreateCategoryReqDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/dto/req/CreateCategoryReqDto.java
@@ -1,0 +1,25 @@
+package com.korit.pawsmarket.domain.category.dto.req;
+
+import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateCategoryReqDto(
+
+        @Schema(description = "카테고리 유형", example = "FOOD")
+        @NotNull(message = "카테고리 유형을 선택해주세요. " +
+                "FOOD(사료&분유), TREAT(간식), SUPPLEMENT(영양제), TOY(장난감&훈련용품), BATH(목욕용품)")
+        @Enumerated(EnumType.STRING)  // enum을 사용할 때 @Enumerated 어노테이션 추가
+        CategoryType categoryType
+) {
+
+    public Category of() {
+        return Category.builder()
+                .categoryType(this.categoryType)
+                .build();
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/entity/Category.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/entity/Category.java
@@ -1,0 +1,27 @@
+package com.korit.pawsmarket.domain.category.entity;
+
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
+import com.korit.pawsmarket.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "category")
+public class Category extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long categoryId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category_type", unique = true)
+    private CategoryType categoryType;
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/entity/repository/CategoryRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/entity/repository/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.korit.pawsmarket.domain.category.entity.repository;
+
+import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Category readCategoryByCategoryType(CategoryType categoryType);
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/enums/CategoryType.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/enums/CategoryType.java
@@ -1,0 +1,9 @@
+package com.korit.pawsmarket.domain.category.enums;
+
+public enum CategoryType {
+    FOOD,           // 사료&분유
+    TREAT,          // 간식
+    SUPPLEMENT,     // 영양제
+    TOY,            // 장난감&훈련용품
+    BATH            // 목욕용품
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/facade/CategoryFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/facade/CategoryFacade.java
@@ -1,0 +1,31 @@
+package com.korit.pawsmarket.domain.category.facade;
+
+import com.korit.pawsmarket.domain.category.dto.req.CreateCategoryReqDto;
+import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.category.service.CreateCategoryService;
+import com.korit.pawsmarket.domain.category.service.ReadCategoryService;
+import com.korit.pawsmarket.global.exception.DuplicateException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Component
+@RequiredArgsConstructor
+public class CategoryFacade {
+
+    private final CreateCategoryService createCategoryService;
+    private final ReadCategoryService readCategoryService;
+
+    public void createCategory(CreateCategoryReqDto reqDto) {
+        Category foundCategory = readCategoryService.findByCategoryType(reqDto.categoryType());
+
+        if (foundCategory != null) {
+            throw new DuplicateException("이미 존재하는 카테고리입니다.");
+        }
+
+        Category category = reqDto.of();
+
+        createCategoryService.createCategory(category);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/service/CreateCategoryService.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/service/CreateCategoryService.java
@@ -1,0 +1,18 @@
+package com.korit.pawsmarket.domain.category.service;
+
+import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.category.entity.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateCategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public void createCategory(Category category) {
+        categoryRepository.save(category);
+    }
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/service/ReadCategoryService.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/service/ReadCategoryService.java
@@ -1,0 +1,18 @@
+package com.korit.pawsmarket.domain.category.service;
+
+import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.category.entity.repository.CategoryRepository;
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReadCategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public Category findByCategoryType (CategoryType categoryType) {
+        return categoryRepository.readCategoryByCategoryType(categoryType);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/exception/DuplicateException.java
+++ b/src/main/java/com/korit/pawsmarket/global/exception/DuplicateException.java
@@ -1,0 +1,8 @@
+package com.korit.pawsmarket.global.exception;
+
+public class DuplicateException extends CustomException {
+
+    public DuplicateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/exception/ForbiddenException.java
+++ b/src/main/java/com/korit/pawsmarket/global/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package com.korit.pawsmarket.global.exception;
+
+public class ForbiddenException extends CustomException {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/exception/InvalidException.java
+++ b/src/main/java/com/korit/pawsmarket/global/exception/InvalidException.java
@@ -1,0 +1,8 @@
+package com.korit.pawsmarket.global.exception;
+
+public class InvalidException extends CustomException {
+
+    public InvalidException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/exception/NotFoundException.java
+++ b/src/main/java/com/korit/pawsmarket/global/exception/NotFoundException.java
@@ -1,0 +1,6 @@
+package com.korit.pawsmarket.global.exception;
+
+public class NotFoundException extends CustomException {
+
+    public NotFoundException(String message) {  super(message);  }
+}

--- a/src/main/java/com/korit/pawsmarket/global/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/korit/pawsmarket/global/handler/CustomExceptionHandler.java
@@ -1,0 +1,107 @@
+package com.korit.pawsmarket.global.handler;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.korit.pawsmarket.global.exception.CustomException;
+import com.korit.pawsmarket.global.exception.InvalidException;
+import com.korit.pawsmarket.global.response.ApiResponse;
+import com.korit.pawsmarket.global.response.Response;
+import com.korit.pawsmarket.global.response.enums.ResponseCode;
+import com.korit.pawsmarket.global.response.enums.Status;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public final ResponseEntity<Response<String>> handleAllExceptions(Exception e, WebRequest request) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(new Response<String>(ResponseCode.GENERAL_ERROR, e.getMessage()));
+    }
+
+    // 커스텀 예외를 처리하는 메서드
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<String>> handleCustomException(CustomException e) {
+        Status status;
+
+        try {
+            status = Status.valueOf(e.getClass().getSimpleName().replace("Exception", "").toUpperCase());
+            // 예외 이름에서 Exception을 제외 => 상태 값 추출
+        } catch (IllegalArgumentException ex) {
+            status = Status.ERROR;
+            // 상태가 없으면 기본값을 설정
+        }
+
+        log.error("Custom exception : {}", status);
+        return ApiResponse.generateResp(status, e.getMessage(), null);
+    }
+
+    // 유효성 검사 실패시 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(error -> error.getDefaultMessage())
+                .findFirst()    // 첫번째 에러만 반환
+                .orElse("잘못된 요청입니다.");
+
+        log.error("Validation error : {}", errorMessage);
+        return ApiResponse.generateResp(Status.INVALID, errorMessage, null);
+    }
+
+    @ExceptionHandler(InvalidException.class)
+    public ResponseEntity<ApiResponse<String>> handleInvalidException(InvalidException ex) {
+        String errorMessage = ex.getMessage();
+
+        log.error("Invalid data error : {}", errorMessage);
+
+        return ApiResponse.generateResp(Status.INVALID, errorMessage, null);
+    }
+
+    @ExceptionHandler(InvalidFormatException.class)
+    public ResponseEntity<ApiResponse<String>> handleInvalidFormatException(InvalidFormatException ex) {
+        // 잘못 입력된 값 가져오기
+        Object invalidValue = ex.getValue();
+
+        // Enum 클래스 가져오기 (CategoryType과 같은 Enum)
+        Class<?> targetType = ex.getTargetType();
+
+        // Enum에 정의된 모든 값 가져오기
+        String validValues = Arrays.stream(targetType.getEnumConstants())
+                .map(Object::toString)
+                .collect(Collectors.joining(", "));
+
+        // 동적으로 에러 메시지 생성
+        String errorMessage = String.format("잘못된 카테고리 타입입니다. 입력값: [%s], 허용된 값: [%s]", invalidValue, validValues);
+
+        log.error("Enum Parsing Error : {}", errorMessage);
+
+        return ApiResponse.generateResp(Status.INVALID, errorMessage, null);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<String>> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        Throwable cause = ex.getCause(); // 원인 예외 가져오기
+
+        // 원인이 `InvalidFormatException`이면 별도로 처리
+        if (cause instanceof InvalidFormatException invalidFormatException) {
+            return handleInvalidFormatException(invalidFormatException);
+        }
+
+        // 그 외의 경우 일반 JSON 파싱 에러 메시지 반환
+        return ApiResponse.generateResp(Status.ERROR, "잘못된 요청 형식입니다.", null);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/response/ApiResponse.java
+++ b/src/main/java/com/korit/pawsmarket/global/response/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.korit.pawsmarket.global.response;
+
+import com.korit.pawsmarket.global.response.enums.Status;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class ApiResponse<T> {
+
+    private Status status;
+    private String message;
+    private T data;
+
+    public ApiResponse(Status status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> generateResp(
+            Status status, String message, T data
+    ) {
+        ApiResponse<T> apiResponse = new ApiResponse<>(status, message, data);
+        return ResponseEntity.status(status.getHttpStatus()).body(apiResponse);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/response/Response.java
+++ b/src/main/java/com/korit/pawsmarket/global/response/Response.java
@@ -1,0 +1,16 @@
+package com.korit.pawsmarket.global.response;
+
+import com.korit.pawsmarket.global.response.enums.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class Response<T> {
+
+    private ResponseCode code;
+    private T data;
+
+    public Response(ResponseCode responseCode, T message) {
+        this.code = responseCode;
+        this.data = message;
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/response/enums/ResponseCode.java
+++ b/src/main/java/com/korit/pawsmarket/global/response/enums/ResponseCode.java
@@ -1,0 +1,18 @@
+package com.korit.pawsmarket.global.response.enums;
+
+public enum ResponseCode {
+
+    LOGIN_SUCCESS("로그인 성공"),
+    SIGNUP_SUCCESS("회원가입 성공"),
+    GENERAL_ERROR("에러 발생");
+
+    private final String message;
+
+    ResponseCode(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/global/response/enums/Status.java
+++ b/src/main/java/com/korit/pawsmarket/global/response/enums/Status.java
@@ -1,0 +1,35 @@
+package com.korit.pawsmarket.global.response.enums;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum Status {
+
+    // 성공 상태
+    SUCCESS("Success", "요청이 성공적으로 처리된 경우", HttpStatus.OK),
+    CREATE("Create", "리소스가 성공적으로 생성된 경우", HttpStatus.CREATED),
+    UPDATE("Update", "리소스가 성공적으로 수정된 경우", HttpStatus.OK),
+    DELETE("Delete", "리소스가 성공적으로 삭제된 경우", HttpStatus.OK),
+
+    // 실패 상태
+    INVALID("Invalid", "요청 데이터가 잘못된 경우", HttpStatus.BAD_REQUEST),
+    DUPLICATE("Duplicate", "이미 존재하는 데이터로 새롭게 생성하려는 경우", HttpStatus.CONFLICT),
+    NOTFOUND("Not Found", "요청한 리소스가 존재하지 않는 경우", HttpStatus.NOT_FOUND),
+    UNAUTHORIZED("Unauthorized", "인증되지 않은 사용자가 접근하려는 경우", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("Forbidden", "인증은 되었지만 권한이 없는 경우", HttpStatus.FORBIDDEN),
+
+
+    // 에러 상태
+    ERROR("Error", "예상치 못한 예외가 발생한 경우", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String code;
+    private final String description;
+    private final HttpStatus httpStatus;
+
+    Status(String code, String description, HttpStatus httpStatus) {
+        this.code = code;
+        this.description = description;
+        this.httpStatus = httpStatus;
+    }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
카테고리 엔티티를 생성하고, 새로운 카테고리를 추가하는 `createCategory` 기능을 구현했습니다.  
또한, 응답 구조를 설계하여 예외 발생 시 보다 명확한 메시지를 제공하고,  
프론트엔드에서 데이터를 쉽게 처리할 수 있도록 개선했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] **카테고리 엔티티 생성**  
  - `Category` 엔티티 추가  
  - `categoryType`을 `enum` 타입으로 관리하여 사전에 정의된 카테고리만 추가 가능  
  - 유효하지 않은 카테고리 타입 입력 시 예외 발생  
- [x] **createCategory 기능 구현**  
  - 관리자가 `categoryType`을 입력받아 새로운 카테고리 생성  
  - 입력받은 `categoryType`이 이미 존재하는지 중복 여부 확인  
  - 중복된 카테고리 타입 입력 시 `DuplicateException` 발생  
- [x] **응답 구조 설계 및 예외 처리 개선**  
  - `CustomException`을 추가하여 예외 응답 통일  
  - 잘못된 카테고리 타입 입력 시 허용된 값과 함께 상세 에러 메시지 반환  

---

## 📌 참고 사항 (Additional Notes)
기존 이슈에서 기획한 "카테고리 타입 + 펫 타입" 구조를 변경 하였습니다.  
카테고리 엔티티에는 `categoryType`만 포함하고, `petType`은 상품 필드에서 관리할 수 있도록 설계할 예정입니다.
