### PR TITLE
feat: 카테고리 전체 목록 조회 기능

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/controller/CategoryController.java
@@ -1,6 +1,7 @@
 package com.korit.pawsmarket.domain.category.controller;
 
 import com.korit.pawsmarket.domain.category.dto.req.CreateCategoryReqDto;
+import com.korit.pawsmarket.domain.category.dto.resp.GetCategoryRespDto;
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.category.facade.CategoryFacade;
 import com.korit.pawsmarket.global.response.ApiResponse;
@@ -11,10 +12,9 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @Tag(name = "Category", description = "카테고리 API")
@@ -32,5 +32,11 @@ public class CategoryController {
         categoryFacade.createCategory(reqDto);
 
         return ApiResponse.generateResp(Status.CREATE, "새로운 카테고리가 추가되었습니다.", null);
+    }
+
+    @Operation(summary = "카테고리 목록 조회", description = "카테고리의 전체 목록을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<GetCategoryRespDto>>> getCategoryList() {
+        return ApiResponse.generateResp(Status.SUCCESS, null, categoryFacade.getCategoryList());
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/category/dto/resp/GetCategoryRespDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/dto/resp/GetCategoryRespDto.java
@@ -1,0 +1,19 @@
+package com.korit.pawsmarket.domain.category.dto.resp;
+
+import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
+import lombok.Builder;
+
+@Builder
+public record GetCategoryRespDto(
+        Long categoryId,
+        CategoryType categoryType
+) {
+
+    public static GetCategoryRespDto from(Category category) {
+        return GetCategoryRespDto.builder()
+                .categoryId(category.getCategoryId())
+                .categoryType(category.getCategoryType())
+                .build();
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/category/facade/CategoryFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/facade/CategoryFacade.java
@@ -1,6 +1,7 @@
 package com.korit.pawsmarket.domain.category.facade;
 
 import com.korit.pawsmarket.domain.category.dto.req.CreateCategoryReqDto;
+import com.korit.pawsmarket.domain.category.dto.resp.GetCategoryRespDto;
 import com.korit.pawsmarket.domain.category.entity.Category;
 import com.korit.pawsmarket.domain.category.service.CreateCategoryService;
 import com.korit.pawsmarket.domain.category.service.ReadCategoryService;
@@ -8,6 +9,8 @@ import com.korit.pawsmarket.global.exception.DuplicateException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional
 @Component
@@ -27,5 +30,9 @@ public class CategoryFacade {
         Category category = reqDto.of();
 
         createCategoryService.createCategory(category);
+    }
+
+    public List<GetCategoryRespDto> getCategoryList() {
+        return readCategoryService.findAll().stream().map(GetCategoryRespDto::from).toList();
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/category/service/ReadCategoryService.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/service/ReadCategoryService.java
@@ -6,6 +6,8 @@ import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class ReadCategoryService {
@@ -14,5 +16,9 @@ public class ReadCategoryService {
 
     public Category findByCategoryType (CategoryType categoryType) {
         return categoryRepository.readCategoryByCategoryType(categoryType);
+    }
+
+    public List<Category> findAll() {
+        return categoryRepository.findAll();
     }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
카테고리 정보를 효율적으로 조회할 수 있도록 카테고리 전체 목록 조회 API를 추가했습니다.
--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] getCategoryList API 추가: 카테고리 엔티티에 저장된 모든 카테고리를 조회하여 리스트 형식으로 반환
    (이제 홈페이지 헤더에서 동적으로 카테고리 목록을 표시할 수 있도록 데이터 연동할 수 있습니다.)

---

## 📌 참고 사항 (Additional Notes)
이 기능은 홈페이지 헤더에서 사용될 예정이며, 사용자 경험 개선을 위해 적용됩니다.
향후 프론트엔드에서 해당 API를 활용하여 카테고리 목록을 렌더링할 계획입니다.
