### PR TITLE
feat: 상품 목록 조회 시 카테고리 필터링 추가

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/category/facade/CategoryFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/facade/CategoryFacade.java
@@ -32,6 +32,7 @@ public class CategoryFacade {
         createCategoryService.createCategory(category);
     }
 
+    @Transactional(readOnly = true)
     public List<GetCategoryRespDto> getCategoryList() {
         return readCategoryService.findAll().stream().map(GetCategoryRespDto::from).toList();
     }

--- a/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
@@ -1,5 +1,6 @@
 package com.korit.pawsmarket.domain.product.controller;
 
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.facade.ProductFacade;
 import com.korit.pawsmarket.global.response.ApiResponse;
@@ -8,7 +9,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,18 +26,20 @@ public class ProductController {
 
     private final ProductFacade productFacade;
 
-    @Operation(summary = "상품 전체 목록 조회", description = "상품의 전체 목록을 조회합니다.(페이징)")
+    @Operation(summary = "상품 목록 조회", description = "상품 목록을 조회합니다.(페이징)(전체 목록 조회 / 카테고리별 조회 가능)")
     @GetMapping
     public ResponseEntity<ApiResponse<List<GetProductListRespDto>>> getProductList(
             @RequestParam(defaultValue = "0") int pageNo,
             @RequestParam(defaultValue = "10") int pageSize,
             @RequestParam(defaultValue = "salesQuantity") String sortBy,
-            @RequestParam(defaultValue = "desc") String direction
+            @RequestParam(defaultValue = "desc") String direction,
+            @RequestParam(required = false) CategoryType categoryType
     ) {
 
         return ApiResponse.generateResp(
-                Status.SUCCESS,
-                null,
-                productFacade.getProductList(pageNo, pageSize, sortBy, direction).getContent());
+                Status.SUCCESS, null, productFacade
+                        .getProductList(pageNo, pageSize, sortBy, direction, categoryType)
+                        .getContent()
+        );
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/dto/resp/GetProductListRespDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/dto/resp/GetProductListRespDto.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 @Builder
 public record GetProductListRespDto(
         Long productId,
+        Long categoryId,
         String imageUrl,
         String productName,
         int price,
@@ -18,6 +19,7 @@ public record GetProductListRespDto(
     public static GetProductListRespDto from(Product product) {
         return GetProductListRespDto.builder()
                 .productId(product.getProductId())
+                .categoryId(product.getCategory().getCategoryId())
                 .imageUrl(product.getImageUrl())
                 .productName(product.getProductName())
                 .price(product.getPrice())

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
@@ -1,5 +1,6 @@
 package com.korit.pawsmarket.domain.product.entity.repository;
 
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.entity.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,4 +13,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p WHERE p.isDelete = false")
     Page<Product> findAllQuery(Pageable pageable);
+
+    @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.category.categoryType = :categoryType")
+    Page<Product> findAllByCategoryQuery(Pageable pageable, CategoryType categoryType);
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
@@ -1,5 +1,6 @@
 package com.korit.pawsmarket.domain.product.facade;
 
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.category.service.ReadCategoryService;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.service.ReadProductService;
@@ -22,14 +23,19 @@ public class ProductFacade {
 
     private final ReadProductService readProductService;
 
+    @Transactional(readOnly = true)
     public Page<GetProductListRespDto> getProductList(
-            int pageNo, int pageSize, String sortBy, String direction
+            int pageNo, int pageSize, String sortBy, String direction, CategoryType categoryType
     ) {
         Pageable pageable = PageRequest.of(
                 pageNo,
                 pageSize,
                 Sort.by(Sort.Direction.fromString(direction), sortBy));
 
-        return readProductService.findAllQuery(pageable).map(GetProductListRespDto::from);
+        if (categoryType == null) {
+            return readProductService.findAllQuery(pageable).map(GetProductListRespDto::from);
+        }
+
+        return readProductService.findAllByCategoryQuery(pageable, categoryType).map(GetProductListRespDto::from);
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/service/ReadProductService.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/service/ReadProductService.java
@@ -1,5 +1,6 @@
 package com.korit.pawsmarket.domain.product.service;
 
+import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.entity.Product;
 import com.korit.pawsmarket.domain.product.entity.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -15,5 +16,9 @@ public class ReadProductService {
 
     public Page<Product> findAllQuery(Pageable pageable) {
         return productRepository.findAllQuery(pageable);
+    }
+
+    public Page<Product> findAllByCategoryQuery(Pageable pageable, CategoryType categoryType) {
+        return productRepository.findAllByCategoryQuery(pageable, categoryType);
     }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
상품 목록 조회 API에 카테고리 필터링 기능을 추가했습니다.
기존에는 모든 상품 목록을 조회했지만, 카테리 타입을 입력하면 해당 카테고리에 속한 상품만 조회할 수 있도록 개선했습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] @RequestParam(required = false) CategoryType categoryType 추가하여 카테고리 필터링 기능 적용
- [x] GetProductListRespDto에 categoryType 필드 추가하여 응답에 포함
- [x] 파샤드에서 조회 전용 로직에 @Transactional(readOnly = true) 적용하여 성능 최적화
    - 읽기 전용 트랜잭션을 적용해 불필요한 변경 감지를 방지하고 성능을 향상

---

## 📌 참고 사항 (Additional Notes)
카테고리 타입을 입력하면 해당 카테고리의 상품만 조회하고, 입력하지 않으면 전체 목록을 반환합니다.
