### PR TITLE
feat:create-logout-blacklist

### DIFF
--- a/src/main/java/com/korit/pawsmarket/web/api/user/UserController.java
+++ b/src/main/java/com/korit/pawsmarket/web/api/user/UserController.java
@@ -6,12 +6,15 @@ import com.korit.pawsmarket.global.response.enums.Status;
 import com.korit.pawsmarket.web.api.user.req.LoginUserReqDto;
 import com.korit.pawsmarket.web.api.user.req.UserCreateReqDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,6 +44,14 @@ public class UserController {
             return ApiResponse.generateResp(Status.FORBIDDEN, "로그인 실패: 토큰이 생성되지 않았습니다.", null);
         }
         return ApiResponse.generateResp(Status.CREATE, "로그인 성공", token);
+    }
+    @Operation(summary = "로그아웃", security = @SecurityRequirement(name = "bearerAuth"))
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logoutUser(
+            Authentication authentication, HttpServletRequest request
+    ){
+        userFacade.logout(authentication, request);
+        return ApiResponse.generateResp(Status.SUCCESS, "로그아웃 되었습니다.", null);
     }
 
 


### PR DESCRIPTION
## 📝 설명 (Description)
로그아웃 시 JWT를 블랙리스트에 등록하여 더 이상 사용할 수 없도록 처리하였습니다.
이를 통해 로그아웃 후에도 기존 토큰이 남아있는 문제를 방지할 수 있습니다.


--- 

## 🔄 변경 사항 (Changes)
- [ ] JWT 로그아웃 기능 추가  
- [ ] 로그아웃 시 액세스 토큰을 블랙리스트에 등록  
- [ ] Authorization 헤더 유효성 검사 추가  
- [ ] 로그아웃 시 사용자 정보를 로깅하도록 개선  


---

## 📌 참고 사항 (Additional Notes)
- 블랙리스트 처리를 위해 `tokenBlackListService`를 추가하였으며, 만료 시간을 저장하여 자동 삭제될 수 있도록 설정했습니다.  
- 기존의 `session.removeAttribute("cart")` 유지하여 세션 내 장바구니 정보도 함께 삭제됩니다.  
