### PR TITLE
feat: category엔티티에 categoryName추가

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/category/dto/req/CreateCategoryReqDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/dto/req/CreateCategoryReqDto.java
@@ -14,12 +14,16 @@ public record CreateCategoryReqDto(
         @NotNull(message = "카테고리 유형을 선택해주세요. " +
                 "FOOD(사료&분유), TREAT(간식), SUPPLEMENT(영양제), TOY(장난감&훈련용품), BATH(목욕용품)")
         @Enumerated(EnumType.STRING)  // enum을 사용할 때 @Enumerated 어노테이션 추가
-        CategoryType categoryType
+        CategoryType categoryType,
+
+        @Schema(description = "카테고리 이름", example = "사료/분유")
+        String categoryName
 ) {
 
     public Category of() {
         return Category.builder()
                 .categoryType(this.categoryType)
+                .categoryName(this.categoryName)
                 .build();
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/category/dto/resp/GetCategoryRespDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/dto/resp/GetCategoryRespDto.java
@@ -7,13 +7,15 @@ import lombok.Builder;
 @Builder
 public record GetCategoryRespDto(
         Long categoryId,
-        CategoryType categoryType
+        CategoryType categoryType,
+        String categoryName
 ) {
 
     public static GetCategoryRespDto from(Category category) {
         return GetCategoryRespDto.builder()
                 .categoryId(category.getCategoryId())
                 .categoryType(category.getCategoryType())
+                .categoryName(category.getCategoryName())
                 .build();
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/category/entity/Category.java
+++ b/src/main/java/com/korit/pawsmarket/domain/category/entity/Category.java
@@ -24,4 +24,7 @@ public class Category extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "category_type", unique = true)
     private CategoryType categoryType;
+
+    @Column(name = "category_name")
+    private String categoryName;
 }

--- a/src/main/java/com/korit/pawsmarket/domain/user/controller/TestController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/user/controller/TestController.java
@@ -1,13 +1,26 @@
 package com.korit.pawsmarket.domain.user.controller;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 public class TestController {
 
+    // 백 -> 프론트
     @GetMapping("/test")
     public String test() {
         return "백도리";
+    }
+
+    // 프론트 -> 백
+    @PostMapping("/test/name")
+    public void updateName(@RequestBody Map<String, String> request) {
+        String name = request.get("name");
+        System.out.println("***" + name + "***");
     }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
카테고리 엔티티에 categoryName 필드를 추가하고, 관련 DTO에 해당 필드를 반영했습니다.
변경의 목적은 홈페이지 헤더 내비게이션에 카테고리 이름을 표시하기 위함입니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 카테고리 엔티티 수정: categoryName 필드 추가
- [x] 카테고리 생성 요청 DTO 수정: CreateCategoryReqDto에 categoryName 필드 추가
- [x] 카테고리 조회 응답 DTO 수정: GetCategoryRespDto에 categoryName 필드 추가

---

## 📌 참고 사항 (Additional Notes)

