### PR TITLE
feat:Order and OrderDetail Entity

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/entity/OrderDetail.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/entity/OrderDetail.java
@@ -1,0 +1,57 @@
+package com.korit.pawsmarket.domain.OrderDetail.entity;
+
+import com.korit.pawsmarket.domain.OrderDetail.enums.ShippingStatus;
+import com.korit.pawsmarket.domain.order.entity.Order;
+import com.korit.pawsmarket.domain.product.entity.Product;
+import com.korit.pawsmarket.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "order_detail")
+public class OrderDetail extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_detail_id")
+    private Long orderDetailId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn( name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product; // 원가(상품 가격)
+
+    @Column(name = "quantity")
+    private int quantity;
+
+    @Column(name = "price")
+    private int price; //원가 (상품 가격)
+
+    @Column( name = "discount_rate", nullable = false)
+    private int discountRate; // 할인율 (주문 당시 할인율을 저장)
+
+    @Column(name = "final_price", nullable = false)
+    private int finalPrice; //할인 갸격 (price - (price * discountRate / 100))
+
+    @Column(name = "total_price", nullable = false)
+    private int totalPrice; //최종 가격 (finalPrice * quantity)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "shipping_status", nullable = false)
+    private ShippingStatus shippingStatus; // 배송 상태(준비중, 배송중, 배송완료)
+/*
+    @Column(name = "is_refundable", nullable = false)
+    private boolean isRefundable; //환불 여부
+*/
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/enums/ShippingStatus.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/enums/ShippingStatus.java
@@ -1,0 +1,8 @@
+package com.korit.pawsmarket.domain.OrderDetail.enums;
+
+public enum ShippingStatus {
+    READY, //배송 준비 중
+    SHIPPED, //배송 중
+    DELIVERED, //배송 완료
+    CANCELED, //주무 취소 됨
+}

--- a/src/main/java/com/korit/pawsmarket/domain/order/entity/Order.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/entity/Order.java
@@ -1,0 +1,52 @@
+package com.korit.pawsmarket.domain.order.entity;
+
+import com.korit.pawsmarket.domain.OrderDetail.entity.OrderDetail;
+import com.korit.pawsmarket.domain.order.enums.OrderStatus;
+import com.korit.pawsmarket.domain.user.entity.User;
+import com.korit.pawsmarket.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "order")
+public class Order extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "order_id")
+    private Long orderId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "total_price")
+    private int totalPrice; //총 주문 금액
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_status")
+    private OrderStatus orderStatus; //주문 상태(결제 완료, 배송 중 등)
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderDetail> orderDetails; // 주문 상세 목록
+
+    //주문 생성 시 기본 값을 PAYMENT_PENDING으로 설정
+    @PrePersist
+    public void prePersist() {
+        this.orderStatus = OrderStatus.PAYMENT_PENDING;
+    }
+
+    public void updateStatus(OrderStatus newStatus) {
+        this.orderStatus = newStatus;
+    }
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/order/enums/OrderStatus.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/enums/OrderStatus.java
@@ -1,0 +1,11 @@
+package com.korit.pawsmarket.domain.order.enums;
+
+public enum OrderStatus {
+    PAYMENT_PENDING, //결제 대기
+    PAYMENT_COMPLETED, //결제 완료
+    PAYMENT_FAILED, //결제 실패
+    PREPARING_SIPMENT, //배송 준비중
+    SHIPPED, //배송 중
+    DELIVERED, //배송 완료
+    CANCELED //주문 취소
+}


### PR DESCRIPTION
## 📝 설명 (Description)
Order 및 OrderDetail 엔티티를 수정하여 데이터 모델의 일관성을 유지하고, 주문 관련 기능을 개선하였습니다.
변경의 목적은 주문 상세 정보의 정확한 계산 및 배송 상태 관리를 용이하게 하는 것입니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [ ]  OrderDetail 엔티티의 total_price 변수 오타 수정 (totlaPrice → totalPrice)
- [ ] OrderDetail 엔티티에 shippingStatus(배송 상태) 필드 추가
- [ ] Order 엔티티에서 totalPrice 자동 계산 로직 추가
- [ ] isRefundable 필드를 추후 구현을 위해 주석 처리
- [ ] @PrePersist에서 orderStatus의 기본값 설정 검토 및 수정

---

## 📌 참고 사항 (Additional Notes)
OrderStatus와 ShippingStatus 간의 관계를 명확히 정리해야 함
cascade = CascadeType.ALL, orphanRemoval = true 설정이 적절한지 검토 필요
추후 isRefundable 기능 구현 시 반영 예정
예: 의존성 추가, 환경 설정 변경 등.
