### PR TITLE
feat: 상품 목록 조회 기능에 검색 및 펫타입 필터링 추가

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
@@ -4,6 +4,7 @@ import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.dto.req.CreateProductReqDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductDetailRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
+import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.domain.product.facade.ProductFacade;
 import com.korit.pawsmarket.global.response.ApiResponse;
 import com.korit.pawsmarket.global.response.enums.Status;
@@ -12,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -40,14 +42,15 @@ public class ProductController {
             @RequestParam(name = "pageSize", defaultValue = "10") int pageSize,
             @RequestParam(name = "sortBy", defaultValue = "salesQuantity") String sortBy,
             @RequestParam(name = "direction", defaultValue = "desc") String direction,
-            @RequestParam(name = "categoryType", required = false) CategoryType categoryType
+            @RequestParam(name = "categoryType", required = false) CategoryType categoryType,
+            @RequestParam(name = "petType", required = false) PetType petType,
+            @RequestParam(name = "search", required = false) String search
     ) {
+        Page<GetProductListRespDto> productList = productFacade
+                .getProductList(pageNo, pageSize, sortBy, direction, categoryType, petType, search);
+        String totalPages = String.valueOf(productList.getTotalPages());
 
-        return ApiResponse.generateResp(
-                Status.SUCCESS, null, productFacade
-                        .getProductList(pageNo, pageSize, sortBy, direction, categoryType)
-                        .getContent()
-        );
+        return ApiResponse.generateResp(Status.SUCCESS, totalPages, productList.getContent());
     }
 
     @Operation(summary = "상품 상세 조회", description = "상품 ID를 입력하면 해당 상품의 상세 정보를 조회합니다.")

--- a/src/main/java/com/korit/pawsmarket/domain/product/dto/resp/GetProductListRespDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/dto/resp/GetProductListRespDto.java
@@ -1,6 +1,7 @@
 package com.korit.pawsmarket.domain.product.dto.resp;
 
 import com.korit.pawsmarket.domain.product.entity.Product;
+import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.domain.product.enums.SaleStatus;
 import lombok.Builder;
 
@@ -8,6 +9,7 @@ import lombok.Builder;
 public record GetProductListRespDto(
         Long productId,
         Long categoryId,
+        PetType petType,
         String imageUrl,
         String productName,
         int price,
@@ -20,6 +22,7 @@ public record GetProductListRespDto(
         return GetProductListRespDto.builder()
                 .productId(product.getProductId())
                 .categoryId(product.getCategory().getCategoryId())
+                .petType(product.getPetType())
                 .imageUrl(product.getImageUrl())
                 .productName(product.getProductName())
                 .price(product.getPrice())

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
@@ -2,6 +2,7 @@ package com.korit.pawsmarket.domain.product.entity.repository;
 
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.entity.Product;
+import com.korit.pawsmarket.domain.product.enums.PetType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,17 +10,26 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-    @Query("SELECT p FROM Product p WHERE p.isDelete = false")
-    Page<Product> findAllQuery(Pageable pageable);
+    @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.petType IN :petTypes")
+    Page<Product> findAllQuery(Pageable pageable, @Param("petTypes") List<PetType> petTypes);
 
-    @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.category.categoryType = :categoryType")
-    Page<Product> findAllByCategoryQuery(Pageable pageable, @Param("categoryType") CategoryType categoryType);
+    @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.category.categoryType = :categoryType AND p.petType IN :petTypes")
+    Page<Product> findAllByCategoryQuery(Pageable pageable, @Param("categoryType") CategoryType categoryType, @Param("petTypes") List<PetType> petTypes);
 
     @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.productId = :productId")
     Optional<Product> findByIdQuery(@Param("productId") Long productId);
+
+    @Query("SELECT p FROM Product p WHERE p.isDelete = false AND LOWER(p.productName) LIKE LOWER(CONCAT('%', :search, '%')) AND p.petType IN :petTypes")
+    // lower를 이용하여 대소문자 구분없이 검색이 가능하도록 함
+    Page<Product> findAllBySearchQuery(Pageable pageable, @Param("search") String search, @Param("petTypes") List<PetType> petTypes);
+
+    @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.category.categoryType = :categoryType " +
+            "AND LOWER(p.productName) LIKE LOWER(CONCAT('%', :search, '%')) AND p.petType IN :petTypes")
+    Page<Product> findAllByCategoryAndSearchQuery(Pageable pageable, @Param("categoryType") CategoryType categoryType, @Param("search") String search, @Param("petTypes") List<PetType> petTypes);
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
@@ -7,6 +7,7 @@ import com.korit.pawsmarket.domain.product.dto.req.CreateProductReqDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductDetailRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.entity.Product;
+import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.domain.product.service.CreateProductService;
 import com.korit.pawsmarket.domain.product.service.ReadProductService;
 import lombok.RequiredArgsConstructor;
@@ -32,18 +33,45 @@ public class ProductFacade {
 
     @Transactional(readOnly = true)
     public Page<GetProductListRespDto> getProductList(
-            int pageNo, int pageSize, String sortBy, String direction, CategoryType categoryType
+            int pageNo, int pageSize, String sortBy, String direction,
+            CategoryType categoryType, PetType petType, String search
     ) {
+        List<PetType> petTypes;
+
+        if (petType == null) {                  // 전체보기
+            petTypes = List.of(PetType.COMMON, PetType.DOG, PetType.CAT);
+        } else if (petType == PetType.DOG) {    // 강아지
+            petTypes = List.of(PetType.COMMON, PetType.DOG);
+        } else if (petType == PetType.CAT) {    // 고양이
+            petTypes = List.of(PetType.COMMON, PetType.CAT);
+        } else {
+            // 잘못된 값이 들어왔을 때의 기본값 처리 (옵션)
+            petTypes = List.of(PetType.COMMON, PetType.DOG, PetType.CAT);
+        }
+
+
         Pageable pageable = PageRequest.of(
                 pageNo,
                 pageSize,
                 Sort.by(Sort.Direction.fromString(direction), sortBy));
 
-        if (categoryType == null) {
-            return readProductService.findAllQuery(pageable).map(GetProductListRespDto::from);
+        if (categoryType == null && (search == null || search.isEmpty())) {
+            // 1-1. 카테고리 널, 검색어 널 (전체 상품 조회)
+            return readProductService.findAllQuery(pageable, petTypes)
+                    .map(GetProductListRespDto::from);
+        } else if (categoryType == null) {
+            // 1-2. 카테고리 널, 검색어 있음 (검색만 수행)
+            return readProductService.findAllBySearchQuery(pageable, search, petTypes)
+                    .map(GetProductListRespDto::from);
+        } else if (search == null || search.isEmpty()) {
+            // 2-1. 카테고리 있음, 검색어 널 (카테고리 기준 조회)
+            return readProductService.findAllByCategoryQuery(pageable, categoryType, petTypes)
+                    .map(GetProductListRespDto::from);
+        } else {
+            // 2-2. 카테고리 있음, 검색어 있음 (카테고리 + 검색어 조회)
+            return readProductService.findAllByCategoryAndSearchQuery(pageable, categoryType, search, petTypes)
+                    .map(GetProductListRespDto::from);
         }
-
-        return readProductService.findAllByCategoryQuery(pageable, categoryType).map(GetProductListRespDto::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/korit/pawsmarket/domain/product/service/ReadProductService.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/service/ReadProductService.java
@@ -3,11 +3,15 @@ package com.korit.pawsmarket.domain.product.service;
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.entity.Product;
 import com.korit.pawsmarket.domain.product.entity.repository.ProductRepository;
+import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,16 +19,24 @@ public class ReadProductService {
 
     private final ProductRepository productRepository;
 
-    public Page<Product> findAllQuery(Pageable pageable) {
-        return productRepository.findAllQuery(pageable);
+    public Page<Product> findAllQuery(Pageable pageable, List<PetType> petTypes) {
+        return productRepository.findAllQuery(pageable, petTypes);
     }
 
-    public Page<Product> findAllByCategoryQuery(Pageable pageable, CategoryType categoryType) {
-        return productRepository.findAllByCategoryQuery(pageable, categoryType);
+    public Page<Product> findAllByCategoryQuery(Pageable pageable, CategoryType categoryType, List<PetType> petTypes) {
+        return productRepository.findAllByCategoryQuery(pageable, categoryType, petTypes);
     }
 
     public Product findByIdQuery(Long productId) {
         return productRepository.findByIdQuery(productId)
                 .orElseThrow(() -> new NotFoundException("해당 상품을 찾을 수 없습니다."));
+    }
+
+    public Page<Product> findAllBySearchQuery(Pageable pageable, String search, List<PetType> petTypes) {
+        return productRepository.findAllBySearchQuery(pageable, search, petTypes);
+    }
+
+    public Page<Product> findAllByCategoryAndSearchQuery(Pageable pageable, CategoryType categoryType, String search, List<PetType> petTypes) {
+        return productRepository.findAllByCategoryAndSearchQuery(pageable, categoryType, search, petTypes);
     }
 }


### PR DESCRIPTION
## 📝 설명 (Description)
상품 목록 조회 기능에 검색 필터링과 펫타입 필터링을 추가했습니다. 
이로 인해 사용자는 상품을 보다 정교하게 검색하고, 특정 펫타입에 맞는 상품만 조회할 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 상품 목록 조회 DTO에 petType 필드를 추가하여 해당 상품의 타입을 확인할 수 있도록 함
- [x] 상품 목록 조회 API에 검색 필터링과 펫타입 필터링 기능을 구현
    - 사용자가 검색어와 선택한 펫타입에 맞는 상품을 필터링할 수 있도록 기능 추가
---

## 📌 참고 사항 (Additional Notes)

