### PR TITLE
feat: 재고 상태 업데이트 및 상품 입고 주문 기능 추가

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
@@ -60,4 +60,14 @@ public class ProductController {
     ) {
         return ApiResponse.generateResp(Status.SUCCESS, null, productFacade.getProductDetail(productId));
     }
+
+    @Operation(summary = "상품 입고 주문", description = "상품 입고 주문을 하면 일정 시간 이후에 재고가 입고됩니다.")
+    @PostMapping("/{productId}/stock")
+    public ResponseEntity<ApiResponse<Void>> scheduleStockArrival(
+            @PathVariable(name = "productId") Long productId,
+            @RequestParam(name = "quantity") int quantity
+    ) {
+        productFacade.scheduleStockArrival(productId, quantity);
+        return ApiResponse.generateResp(Status.CREATE, "상품 입고 주문이 완료되었습니다.", null);
+    }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
@@ -60,4 +60,12 @@ public class Product extends BaseEntity {
 
     @Column(name = "discount_rate")
     private int discountRate;               // 할인율
+
+    public void updateSaleStatus(SaleStatus saleStatus) {
+        this.saleStatus = saleStatus;
+    }
+
+    public void updateStock(int quantity) {
+        this.stock = quantity;
+    }
 }

--- a/src/main/java/com/korit/pawsmarket/global/config/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/korit/pawsmarket/global/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.korit.pawsmarket.global.config.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@Slf4j
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);   // 동시에 실행할 스레드 수 설정
+        scheduler.setThreadNamePrefix("scheduled-task-");   // 스레드 이름 접두사
+        scheduler.setAwaitTerminationSeconds(300);  // 이미 실행 중인 작업을 기다릴 최대 시간
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);    // 작업 완료까지 스프링 종료를 대기
+        scheduler.initialize();     // 스케줄러 초기화
+
+        return scheduler;
+    }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
이번 PR은 상품의 재고 상태를 업데이트하고, 입고 주문을 예약하여 일정 시간 후 재고를 증가시키는 기능을 추가합니다.
이 기능을 통해 상품의 판매 상태는 재고 수량에 따라 동적으로 변경되며, 입고된 상품의 재고 수량도 자동으로 반영됩니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 재고 상태 업데이트 기능: 재고 수량에 따라 상품의 판매 상태(판매중, 일시품절)를 자동으로 변경하는 로직 추가.
(재고의 변동이 있을 때마다 productFacade.checkSaleStatus(productId);를 호출하면 판매 상태가 자동으로 변경됩니다.)
- [x] 상품 입고 주문 기능: 입고된 상품에 대해 임의로 도착 시간을 설정하여 재고를 증가시키는 기능 추가.
(입고 주문은 taskScheduler를 사용하여 예약되고, 설정된 시간 후 재고가 증가합니다.)

---

## 📌 참고 사항 (Additional Notes)
- 입고된 상품의 도착 시간을 테스트 용도로 3분 뒤로 설정하였으므로, 실제 환경에서는 입고 시간을 실제 비즈니스 로직에 맞게 조정할 필요가 있을 수 있습니다.
- taskScheduler를 사용하여 입고 시간을 예약하고, 해당 시간에 맞춰 재고가 자동으로 증가합니다.
