### PR TITLE
feat: 상품 정보 수정 기능

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.korit.pawsmarket.domain.product.controller;
 
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.dto.req.CreateProductReqDto;
+import com.korit.pawsmarket.domain.product.dto.req.UpdateProductReqDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductDetailRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.enums.PetType;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.sql.Update;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -69,5 +71,18 @@ public class ProductController {
     ) {
         productFacade.scheduleStockArrival(productId, quantity);
         return ApiResponse.generateResp(Status.CREATE, "상품 입고 주문이 완료되었습니다.", null);
+    }
+
+    @Operation(summary = "상품 정보 수정", description = "상품 정보를 수정합니다. 상품명, 가격, 카테고리, 펫 타입, 할인율, 판매 상태, 설명, 이미지를 수정할 수 있습니다.")
+    @PutMapping("/{productId}")
+    public ResponseEntity<ApiResponse<Void>> updateProduct(
+            @PathVariable(name = "productId") Long productId,
+            @Valid @RequestBody UpdateProductReqDto reqDto
+            ) {
+        log.info("*** productId : {} ***", productId);
+        log.info("*** reqDto : {} ***", reqDto);
+        productFacade.updateProduct(productId, reqDto);
+
+        return ApiResponse.generateResp(Status.UPDATE, "상품 정보가 성공적으로 업데이트되었습니다.", null);
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
@@ -60,4 +60,14 @@ public class ProductController {
     ) {
         return ApiResponse.generateResp(Status.SUCCESS, null, productFacade.getProductDetail(productId));
     }
+
+    @Operation(summary = "상품 입고 주문", description = "상품 입고 주문을 하면 일정 시간 이후에 재고가 입고됩니다.")
+    @PostMapping("/{productId}/stock")
+    public ResponseEntity<ApiResponse<Void>> scheduleStockArrival(
+            @PathVariable(name = "productId") Long productId,
+            @RequestParam(name = "quantity") int quantity
+    ) {
+        productFacade.scheduleStockArrival(productId, quantity);
+        return ApiResponse.generateResp(Status.CREATE, "상품 입고 주문이 완료되었습니다.", null);
+    }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/dto/req/UpdateProductReqDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/dto/req/UpdateProductReqDto.java
@@ -1,0 +1,57 @@
+package com.korit.pawsmarket.domain.product.dto.req;
+
+import com.korit.pawsmarket.domain.product.enums.PetType;
+import com.korit.pawsmarket.domain.product.enums.SaleStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
+
+public record UpdateProductReqDto(
+
+        @Schema(description = "카테고리 유형", example = "FOOD")
+        @NotNull(message = "해당 상품의 카테고리를 입력해주세요.")
+        Long categoryId,
+
+        @Schema(description = "상품명", example = "데일리 트릿 (연어/닭가슴살/명태)")
+        @NotBlank(message = "상품명을 입력해주세요.")
+        String productName,
+
+        @Schema(description = "가격", example = "22000")
+        @NotNull(message = "가격을 입력해주세요")
+        @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+        int price,
+
+        @Schema(description = "대표 이미지", example = "대표 이미지 url")
+        @NotBlank(message = "대표 이미지를 등록해주세요.")
+        String imageUrl,
+
+        @Schema(description = "판매 상태", example = "ON_SALE")
+        @NotNull(message = "판매 상태를 선택해주세요.     ON_SALE(판매중), OUT_OF_STOCK(일시 품절), DISCONTINUED(단종/판매 중단)")
+        @Enumerated(EnumType.STRING)
+        SaleStatus saleStatus,
+
+        @Schema(description = "상품 설명 이미지 1", example = "상품 설명 이미지 url 1")
+        @NotBlank(message = "상품 설명 이미지를 등록해주세요.")
+        String descriptionImageUrl1,
+
+        @Schema(description = "상품 설명 이미지 2", example = "상품 설명 이미지 url 2")
+        String descriptionImageUrl2,
+
+        @Schema(description = "상품 설명 이미지 3", example = "상품 설명 이미지 url 3")
+        String descriptionImageUrl3,
+
+        @Schema(description = "해당 상품의 사용 대상이 되는 반려동물 유형", example = "COMMON")
+        @NotNull(message = "반려동물 유형을 선택해주세요. COMMON(공용), DOG(강아지), CAT(고양이)")
+        @Enumerated(EnumType.STRING)
+        PetType petType,
+
+        @Schema(description = "할인율", example = "0")
+        @Range(min = 0, max = 100, message = "할인율은 0 이상 100 이하여야 합니다.")
+        @NotNull(message = "할인율을 입력해주세요.")
+        int discountRate
+) {
+}

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
@@ -1,6 +1,7 @@
 package com.korit.pawsmarket.domain.product.entity;
 
 import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.product.dto.req.UpdateProductReqDto;
 import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.domain.product.enums.SaleStatus;
 import com.korit.pawsmarket.global.entity.BaseEntity;
@@ -67,5 +68,18 @@ public class Product extends BaseEntity {
 
     public void updateStock(int quantity) {
         this.stock = quantity;
+    }
+
+    public void updateProduct(UpdateProductReqDto reqDto, Category category) {
+        this.category = category;
+        this.productName = reqDto.productName();
+        this.price = reqDto.price();
+        this.imageUrl = reqDto.imageUrl();
+        this.saleStatus = reqDto.saleStatus();
+        this.descriptionImageUrl1 = reqDto.descriptionImageUrl1();
+        this.descriptionImageUrl2 = reqDto.descriptionImageUrl2();
+        this.descriptionImageUrl3 = reqDto.descriptionImageUrl3();
+        this.petType = reqDto.petType();
+        this.discountRate = reqDto.discountRate();
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
@@ -60,4 +60,12 @@ public class Product extends BaseEntity {
 
     @Column(name = "discount_rate")
     private int discountRate;               // 할인율
+
+    public void updateSaleStatus(SaleStatus saleStatus) {
+        this.saleStatus = saleStatus;
+    }
+
+    public void updateStock(int quantity) {
+        this.stock = quantity;
+    }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
@@ -4,6 +4,7 @@ import com.korit.pawsmarket.domain.category.entity.Category;
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.category.service.ReadCategoryService;
 import com.korit.pawsmarket.domain.product.dto.req.CreateProductReqDto;
+import com.korit.pawsmarket.domain.product.dto.req.UpdateProductReqDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductDetailRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.entity.Product;
@@ -11,6 +12,7 @@ import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.domain.product.enums.SaleStatus;
 import com.korit.pawsmarket.domain.product.service.CreateProductService;
 import com.korit.pawsmarket.domain.product.service.ReadProductService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -135,6 +137,14 @@ public class ProductFacade {
 
         // 판매 상태 점검
         checkSaleStatus(productId);
+        createProductService.save(product);
+    }
+
+    public void updateProduct(Long productId, UpdateProductReqDto reqDto) {
+        Product product = readProductService.findByIdQuery(productId);
+        Category category = readCategoryService.findById(reqDto.categoryId());
+
+        product.updateProduct(reqDto, category);
         createProductService.save(product);
     }
 }

--- a/src/main/java/com/korit/pawsmarket/global/config/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/korit/pawsmarket/global/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.korit.pawsmarket.global.config.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@Slf4j
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);   // 동시에 실행할 스레드 수 설정
+        scheduler.setThreadNamePrefix("scheduled-task-");   // 스레드 이름 접두사
+        scheduler.setAwaitTerminationSeconds(300);  // 이미 실행 중인 작업을 기다릴 최대 시간
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);    // 작업 완료까지 스프링 종료를 대기
+        scheduler.initialize();     // 스케줄러 초기화
+
+        return scheduler;
+    }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
상품 정보를 수정하는 기능을 구현했습니다. 
관리자는 상품의 대표 이미지, 상품명, 가격, 카테고리, 펫 타입, 할인율, 판매 상태, 설명 이미지 등을 수정할 수 있습니다. 
해당 기능을 통해 상품 정보를 효율적으로 관리할 수 있습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 상품 정보 수정 API: 상품 정보를 수정할 수 있는 API를 추가했습니다. (PUT /products/{productId})
- [x] 상품 수정 로직 구현: Product 엔티티에 updateProduct 메서드를 추가하여 수정 로직을 구현했습니다.
- [x] 상품 수정 DTO 추가: 수정 시 필요한 데이터를 받기 위한 UpdateProductReqDto를 추가했습니다.
---

## 📌 참고 사항 (Additional Notes)
상품의 재고와 판매 수량은 해당 기능에서 수정하지 않습니다. 
재고 관리는 별도의 기능에서 처리되며, 판매 수량은 판매 기록에 따라 업데이트됩니다.
