### PR TITLE
feat: 재고 부족 상품 목록 조회

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
@@ -2,6 +2,7 @@ package com.korit.pawsmarket.domain.product.controller;
 
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.product.dto.req.CreateProductReqDto;
+import com.korit.pawsmarket.domain.product.dto.req.UpdateProductReqDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductDetailRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.enums.PetType;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.sql.Update;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -69,5 +71,18 @@ public class ProductController {
     ) {
         productFacade.scheduleStockArrival(productId, quantity);
         return ApiResponse.generateResp(Status.CREATE, "상품 입고 주문이 완료되었습니다.", null);
+    }
+
+    @Operation(summary = "상품 정보 수정", description = "상품 정보를 수정합니다. 상품명, 가격, 카테고리, 펫 타입, 할인율, 판매 상태, 설명, 이미지를 수정할 수 있습니다.")
+    @PutMapping("/{productId}")
+    public ResponseEntity<ApiResponse<Void>> updateProduct(
+            @PathVariable(name = "productId") Long productId,
+            @Valid @RequestBody UpdateProductReqDto reqDto
+            ) {
+        log.info("*** productId : {} ***", productId);
+        log.info("*** reqDto : {} ***", reqDto);
+        productFacade.updateProduct(productId, reqDto);
+
+        return ApiResponse.generateResp(Status.UPDATE, "상품 정보가 성공적으로 업데이트되었습니다.", null);
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/controller/ProductController.java
@@ -60,4 +60,14 @@ public class ProductController {
     ) {
         return ApiResponse.generateResp(Status.SUCCESS, null, productFacade.getProductDetail(productId));
     }
+
+    @Operation(summary = "상품 입고 주문", description = "상품 입고 주문을 하면 일정 시간 이후에 재고가 입고됩니다.")
+    @PostMapping("/{productId}/stock")
+    public ResponseEntity<ApiResponse<Void>> scheduleStockArrival(
+            @PathVariable(name = "productId") Long productId,
+            @RequestParam(name = "quantity") int quantity
+    ) {
+        productFacade.scheduleStockArrival(productId, quantity);
+        return ApiResponse.generateResp(Status.CREATE, "상품 입고 주문이 완료되었습니다.", null);
+    }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/dto/req/UpdateProductReqDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/dto/req/UpdateProductReqDto.java
@@ -1,0 +1,57 @@
+package com.korit.pawsmarket.domain.product.dto.req;
+
+import com.korit.pawsmarket.domain.product.enums.PetType;
+import com.korit.pawsmarket.domain.product.enums.SaleStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Range;
+
+public record UpdateProductReqDto(
+
+        @Schema(description = "카테고리 유형", example = "FOOD")
+        @NotNull(message = "해당 상품의 카테고리를 입력해주세요.")
+        Long categoryId,
+
+        @Schema(description = "상품명", example = "데일리 트릿 (연어/닭가슴살/명태)")
+        @NotBlank(message = "상품명을 입력해주세요.")
+        String productName,
+
+        @Schema(description = "가격", example = "22000")
+        @NotNull(message = "가격을 입력해주세요")
+        @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+        int price,
+
+        @Schema(description = "대표 이미지", example = "대표 이미지 url")
+        @NotBlank(message = "대표 이미지를 등록해주세요.")
+        String imageUrl,
+
+        @Schema(description = "판매 상태", example = "ON_SALE")
+        @NotNull(message = "판매 상태를 선택해주세요.     ON_SALE(판매중), OUT_OF_STOCK(일시 품절), DISCONTINUED(단종/판매 중단)")
+        @Enumerated(EnumType.STRING)
+        SaleStatus saleStatus,
+
+        @Schema(description = "상품 설명 이미지 1", example = "상품 설명 이미지 url 1")
+        @NotBlank(message = "상품 설명 이미지를 등록해주세요.")
+        String descriptionImageUrl1,
+
+        @Schema(description = "상품 설명 이미지 2", example = "상품 설명 이미지 url 2")
+        String descriptionImageUrl2,
+
+        @Schema(description = "상품 설명 이미지 3", example = "상품 설명 이미지 url 3")
+        String descriptionImageUrl3,
+
+        @Schema(description = "해당 상품의 사용 대상이 되는 반려동물 유형", example = "COMMON")
+        @NotNull(message = "반려동물 유형을 선택해주세요. COMMON(공용), DOG(강아지), CAT(고양이)")
+        @Enumerated(EnumType.STRING)
+        PetType petType,
+
+        @Schema(description = "할인율", example = "0")
+        @Range(min = 0, max = 100, message = "할인율은 0 이상 100 이하여야 합니다.")
+        @NotNull(message = "할인율을 입력해주세요.")
+        int discountRate
+) {
+}

--- a/src/main/java/com/korit/pawsmarket/domain/product/dto/resp/GetLowStockProductRespDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/dto/resp/GetLowStockProductRespDto.java
@@ -1,0 +1,26 @@
+package com.korit.pawsmarket.domain.product.dto.resp;
+
+import com.korit.pawsmarket.domain.product.entity.Product;
+import com.korit.pawsmarket.domain.product.enums.PetType;
+import com.korit.pawsmarket.domain.product.enums.SaleStatus;
+import lombok.Builder;
+
+@Builder
+public record GetLowStockProductRespDto(
+        Long productId,
+        String imageUrl,
+        String productName,
+        SaleStatus saleStatus,
+        int stock
+) {
+
+    public static GetLowStockProductRespDto from(Product product) {
+        return GetLowStockProductRespDto.builder()
+                .productId(product.getProductId())
+                .imageUrl(product.getImageUrl())
+                .productName(product.getProductName())
+                .saleStatus(product.getSaleStatus())
+                .stock(product.getStock())
+                .build();
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
@@ -1,6 +1,7 @@
 package com.korit.pawsmarket.domain.product.entity;
 
 import com.korit.pawsmarket.domain.category.entity.Category;
+import com.korit.pawsmarket.domain.product.dto.req.UpdateProductReqDto;
 import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.domain.product.enums.SaleStatus;
 import com.korit.pawsmarket.global.entity.BaseEntity;
@@ -67,5 +68,18 @@ public class Product extends BaseEntity {
 
     public void updateStock(int quantity) {
         this.stock = quantity;
+    }
+
+    public void updateProduct(UpdateProductReqDto reqDto, Category category) {
+        this.category = category;
+        this.productName = reqDto.productName();
+        this.price = reqDto.price();
+        this.imageUrl = reqDto.imageUrl();
+        this.saleStatus = reqDto.saleStatus();
+        this.descriptionImageUrl1 = reqDto.descriptionImageUrl1();
+        this.descriptionImageUrl2 = reqDto.descriptionImageUrl2();
+        this.descriptionImageUrl3 = reqDto.descriptionImageUrl3();
+        this.petType = reqDto.petType();
+        this.discountRate = reqDto.discountRate();
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
@@ -60,4 +60,12 @@ public class Product extends BaseEntity {
 
     @Column(name = "discount_rate")
     private int discountRate;               // 할인율
+
+    public void updateSaleStatus(SaleStatus saleStatus) {
+        this.saleStatus = saleStatus;
+    }
+
+    public void updateStock(int quantity) {
+        this.stock = quantity;
+    }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
@@ -32,4 +32,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.category.categoryType = :categoryType " +
             "AND LOWER(p.productName) LIKE LOWER(CONCAT('%', :search, '%')) AND p.petType IN :petTypes")
     Page<Product> findAllByCategoryAndSearchQuery(Pageable pageable, @Param("categoryType") CategoryType categoryType, @Param("search") String search, @Param("petTypes") List<PetType> petTypes);
+
+    @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.stock <= :threshold")
+    Page<Product> findAllByThreshold(Pageable pageable, @Param("threshold") int threshold);
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
@@ -5,6 +5,7 @@ import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.category.service.ReadCategoryService;
 import com.korit.pawsmarket.domain.product.dto.req.CreateProductReqDto;
 import com.korit.pawsmarket.domain.product.dto.req.UpdateProductReqDto;
+import com.korit.pawsmarket.domain.product.dto.resp.GetLowStockProductRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductDetailRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.entity.Product;
@@ -146,5 +147,14 @@ public class ProductFacade {
 
         product.updateProduct(reqDto, category);
         createProductService.save(product);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<GetLowStockProductRespDto> getLowStockProducts(
+            int pageNo, int pageSize, String sortBy, String direction, int threshold
+    ) {
+        Pageable pageable = PageRequest.of(pageNo, pageSize, Sort.by(Sort.Direction.fromString(direction), sortBy));
+
+        return readProductService.findAllByThreshold(pageable, threshold).map(GetLowStockProductRespDto::from);
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/facade/ProductFacade.java
@@ -4,6 +4,7 @@ import com.korit.pawsmarket.domain.category.entity.Category;
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
 import com.korit.pawsmarket.domain.category.service.ReadCategoryService;
 import com.korit.pawsmarket.domain.product.dto.req.CreateProductReqDto;
+import com.korit.pawsmarket.domain.product.dto.req.UpdateProductReqDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductDetailRespDto;
 import com.korit.pawsmarket.domain.product.dto.resp.GetProductListRespDto;
 import com.korit.pawsmarket.domain.product.entity.Product;
@@ -11,6 +12,7 @@ import com.korit.pawsmarket.domain.product.enums.PetType;
 import com.korit.pawsmarket.domain.product.enums.SaleStatus;
 import com.korit.pawsmarket.domain.product.service.CreateProductService;
 import com.korit.pawsmarket.domain.product.service.ReadProductService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -135,6 +137,14 @@ public class ProductFacade {
 
         // 판매 상태 점검
         checkSaleStatus(productId);
+        createProductService.save(product);
+    }
+
+    public void updateProduct(Long productId, UpdateProductReqDto reqDto) {
+        Product product = readProductService.findByIdQuery(productId);
+        Category category = readCategoryService.findById(reqDto.categoryId());
+
+        product.updateProduct(reqDto, category);
         createProductService.save(product);
     }
 }

--- a/src/main/java/com/korit/pawsmarket/domain/product/service/ReadProductService.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/service/ReadProductService.java
@@ -1,6 +1,7 @@
 package com.korit.pawsmarket.domain.product.service;
 
 import com.korit.pawsmarket.domain.category.enums.CategoryType;
+import com.korit.pawsmarket.domain.product.dto.resp.GetLowStockProductRespDto;
 import com.korit.pawsmarket.domain.product.entity.Product;
 import com.korit.pawsmarket.domain.product.entity.repository.ProductRepository;
 import com.korit.pawsmarket.domain.product.enums.PetType;
@@ -38,5 +39,9 @@ public class ReadProductService {
 
     public Page<Product> findAllByCategoryAndSearchQuery(Pageable pageable, CategoryType categoryType, String search, List<PetType> petTypes) {
         return productRepository.findAllByCategoryAndSearchQuery(pageable, categoryType, search, petTypes);
+    }
+
+    public Page<Product> findAllByThreshold(Pageable pageable, int threshold) {
+        return productRepository.findAllByThreshold(pageable, threshold);
     }
 }

--- a/src/main/java/com/korit/pawsmarket/global/config/scheduler/SchedulerConfig.java
+++ b/src/main/java/com/korit/pawsmarket/global/config/scheduler/SchedulerConfig.java
@@ -1,0 +1,23 @@
+package com.korit.pawsmarket.global.config.scheduler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@Slf4j
+public class SchedulerConfig {
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5);   // 동시에 실행할 스레드 수 설정
+        scheduler.setThreadNamePrefix("scheduled-task-");   // 스레드 이름 접두사
+        scheduler.setAwaitTerminationSeconds(300);  // 이미 실행 중인 작업을 기다릴 최대 시간
+        scheduler.setWaitForTasksToCompleteOnShutdown(true);    // 작업 완료까지 스프링 종료를 대기
+        scheduler.initialize();     // 스케줄러 초기화
+
+        return scheduler;
+    }
+}


### PR DESCRIPTION
## 📝 설명 (Description)
- 재고 수량이 기준 이하인 상품 목록을 조회하는 기능을 구현했습니다.
- 기본 기준값은 5로 설정되어 있으며 원하는 값으로 변경 가능합니다.
- 페이지네이션과 정렬 기능이 포함되어 있습니다.
- 목적: 관리자가 재고 부족 상태를 쉽게 확인하고, 적절한 조치를 신속히 취할 수 있도록 돕기 위해 추가되었습니다.

--- 

## 🔄 변경 사항 (Changes)
이번 PR에서 수행된 변경 사항들을 정리해주세요:
- [x] 재고 부족 상품 목록 조회 API 추가 : GET /products/stock 엔드포인트 구현
    - 기준 수량 이하인 상품 목록을 조회 (기본 기준값: 5)
    - 페이지네이션 (pageNo, pageSize)과 정렬 (sortBy, direction) 기능 포함
- [x] @Query를 사용하여 stock 기준으로 상품 필터링
- [x] DTO 클래스 (GetLowStockProductRespDto) 작성
- [x] API 응답에 총 페이지 수를 포함하여 사용자 경험 개선

---

## 📌 참고 사항 (Additional Notes)
기본 기준값: threshold를 지정하지 않으면 기본값 5를 사용합니다.
