### PR TITLE
feat:createOrder and OrderDetail

### DIFF
--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/dto/req/CreateOrderDetailReqDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/dto/req/CreateOrderDetailReqDto.java
@@ -1,0 +1,19 @@
+package com.korit.pawsmarket.domain.OrderDetail.dto.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateOrderDetailReqDto(
+        @Schema(description = "상품 ID", example = "1")
+        @NotNull(message = "상품 ID는 필수입니다.")
+        Long productId,
+
+        @Schema(description = "주문 수량", example = "30")
+        @NotNull(message = "주문 수량은 필수입니다.")
+        @Min(value = 1, message = "최소 1개의 상품을 주문해야 합니다.")
+        int quantity
+) {
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/dto/resp/CreateOrderDetailRespDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/dto/resp/CreateOrderDetailRespDto.java
@@ -1,0 +1,34 @@
+package com.korit.pawsmarket.domain.OrderDetail.dto.resp;
+
+import com.korit.pawsmarket.domain.OrderDetail.entity.OrderDetail;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateOrderDetailRespDto(
+        @Schema(description = "상품 ID", example = "1")
+        @NotNull(message = "상품 ID는 필수입니다.")
+        Long productId,
+
+        @Schema(description = "주문 수량", example = "30")
+        @NotNull(message = "주문 수량은 필수입니다.")
+        @Min(value = 1, message = "최소 1개의 상품을 주문해야 합니다.")
+        int quantity,
+
+        @Schema(description = "할인율", example = "10")
+        int discountRate,
+
+        @Schema(description = "배송 상태", example = "SHIPPED")
+        @NotBlank(message = "주문 상태는 필수입니다.")
+        String shippingStatus
+) {
+    public static CreateOrderDetailRespDto from(OrderDetail orderDetail) {
+        return new CreateOrderDetailRespDto(
+                orderDetail.getProduct().getProductId(),
+                orderDetail.getQuantity(),
+                orderDetail.getDiscountRate(),
+                orderDetail.getShippingStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/entity/OrderDetail.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/entity/OrderDetail.java
@@ -23,9 +23,9 @@ public class OrderDetail extends BaseEntity {
     @Column(name = "order_detail_id")
     private Long orderDetailId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn( name = "order_id", nullable = false)
-    private Order order;
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order; //주문 정보
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id", nullable = false)
@@ -38,7 +38,8 @@ public class OrderDetail extends BaseEntity {
     private int price; //원가 (상품 가격)
 
     @Column( name = "discount_rate", nullable = false)
-    private int discountRate; // 할인율 (주문 당시 할인율을 저장)
+    @Builder.Default
+    private int discountRate = 0; // 할인율 (주문 당시 할인율을 저장)
 
     @Column(name = "final_price", nullable = false)
     private int finalPrice; //할인 갸격 (price - (price * discountRate / 100))
@@ -49,9 +50,5 @@ public class OrderDetail extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "shipping_status", nullable = false)
     private ShippingStatus shippingStatus; // 배송 상태(준비중, 배송중, 배송완료)
-/*
-    @Column(name = "is_refundable", nullable = false)
-    private boolean isRefundable; //환불 여부
-*/
 
 }

--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/entity/repository/OrderDetailRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/entity/repository/OrderDetailRepository.java
@@ -1,0 +1,10 @@
+package com.korit.pawsmarket.domain.OrderDetail.entity.repository;
+
+import com.korit.pawsmarket.domain.OrderDetail.entity.OrderDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderDetailRepository extends JpaRepository<OrderDetail, Long> {
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/enums/ShippingStatus.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/enums/ShippingStatus.java
@@ -1,8 +1,8 @@
 package com.korit.pawsmarket.domain.OrderDetail.enums;
 
 public enum ShippingStatus {
-    READY, //배송 준비 중
-    SHIPPED, //배송 중
-    DELIVERED, //배송 완료
-    CANCELED, //주무 취소 됨
+    READY, //배송 준비 중 (결제 대기)
+    SHIPPED, //배송 중 (입금 완료)
+    DELIVERED, //배송 완료 (3일 후)
+    CANCELED, //주문 취소 됨
 }

--- a/src/main/java/com/korit/pawsmarket/domain/OrderDetail/facde/OrderDetailFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/OrderDetail/facde/OrderDetailFacade.java
@@ -1,0 +1,48 @@
+package com.korit.pawsmarket.domain.OrderDetail.facde;
+
+import com.korit.pawsmarket.domain.OrderDetail.entity.OrderDetail;
+import com.korit.pawsmarket.domain.OrderDetail.entity.repository.OrderDetailRepository;
+import com.korit.pawsmarket.domain.OrderDetail.enums.ShippingStatus;
+import com.korit.pawsmarket.domain.order.entity.Order;
+import com.korit.pawsmarket.domain.product.entity.Product;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@Transactional
+@RequiredArgsConstructor
+public class OrderDetailFacade {
+
+    private final OrderDetailRepository orderDetailRepository;
+
+    public OrderDetail createOrderDetail(Order order, Product product, int quantity) {
+
+        //재고 차감 로직
+        if (product.getStock() < quantity) {
+            throw new IllegalArgumentException("재고 부족: 상품 ID " + product.getProductId() +", 남은 재고" + product.getStock());
+        }
+        product.decreaseStock(quantity);
+        // 최종 가격 계산
+        int originalPrice = product.getPrice(); // 원래 가격
+        int discountRate = product.getDiscountRate(); // 할인율
+        int discountedPrice = originalPrice - (originalPrice * discountRate / 100); // 할인 적용된 가격
+        int totalPrice = discountedPrice * quantity; // 전체 가격
+
+        // 할인율 계산된 OrderDetail 객체 생성
+        OrderDetail orderDetail = OrderDetail.builder()
+                .order(order)
+                .product(product)
+                .quantity(quantity)
+                .price(originalPrice) // 원래 가격 저장
+                .discountRate(discountRate) // 할인율 저장
+                .finalPrice(discountedPrice) // 할인 적용된 개당 가격
+                .totalPrice(totalPrice) // 총 가격 저장
+                .shippingStatus(ShippingStatus.READY) // 배송 상태 기본값 설정
+                .build();
+
+        return orderDetailRepository.save(orderDetail);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/order/controller/OrderController.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/controller/OrderController.java
@@ -1,0 +1,33 @@
+package com.korit.pawsmarket.domain.order.controller;
+
+import com.korit.pawsmarket.domain.order.dto.req.CreateOrderReqDto;
+import com.korit.pawsmarket.domain.order.facade.OrderFacade;
+import com.korit.pawsmarket.global.response.ApiResponse;
+import com.korit.pawsmarket.global.response.enums.Status;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@Tag(name = "Order", description = "주문 API")
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+public class OrderController {
+
+    private final OrderFacade orderFacade;
+
+    @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createOrder (@Valid @RequestBody CreateOrderReqDto req) {
+        orderFacade.createOrder(req);
+        return ApiResponse.generateResp(Status.CREATE, "새로운 주문이 추가되었습니다.", null);
+    }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/order/dto/req/CreateOrderReqDto.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/dto/req/CreateOrderReqDto.java
@@ -1,0 +1,43 @@
+package com.korit.pawsmarket.domain.order.dto.req;
+
+import com.korit.pawsmarket.domain.OrderDetail.dto.req.CreateOrderDetailReqDto;
+import com.korit.pawsmarket.domain.order.entity.Order;
+import com.korit.pawsmarket.domain.order.enums.OrderStatus;
+import com.korit.pawsmarket.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record CreateOrderReqDto(
+        @Schema(description = "주문자 ID", example = "1")
+        @NotNull(message = "유저 ID는 필수입니다.")
+        Long userId,
+
+        @Schema(description = "수령인", example = "백도은")
+        @NotBlank(message = "수령인 입력은 필수입니다.")
+        String receiverName,
+
+        @Schema(description = "배송지", example = "서울시 강남구")
+        @NotBlank(message = "배송지 입력은 필수입니다.")
+        String shippingAddress,
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        @NotBlank(message = "전화번호 입력은 필수입니다.")
+        String receiverPhone,
+
+        @Schema(description = "주문 상세", example = "")
+        @NotNull(message = "주문 상세 내역은 필수입니다.")
+        List<CreateOrderDetailReqDto> orderDetails
+) {
+        public Order toEntity(User user) {
+                return Order.builder()
+                        .user(user)
+                        .receiverName(receiverName)
+                        .shippingAddress(shippingAddress)
+                        .receiverPhone(receiverPhone)
+                        .orderStatus(OrderStatus.PAYMENT_PENDING)
+                        .build();
+        }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/order/entity/Order.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/entity/Order.java
@@ -17,7 +17,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "order")
+@Table(name = "orders")
 public class Order extends BaseEntity {
 
     @Id
@@ -36,17 +36,16 @@ public class Order extends BaseEntity {
     @Column(name = "order_status")
     private OrderStatus orderStatus; //주문 상태(결제 완료, 배송 중 등)
 
+    @Column(name = "shipping_address", nullable = false)
+    private String shippingAddress; // 배송지 기본값: User.address
+
+    @Column(name = "receiver_name", nullable = false)
+    private String receiverName; // 수령인 기본값: User.nick
+
+    @Column(name = "receiver_phone", nullable = false)
+    private String receiverPhone;
+
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderDetail> orderDetails; // 주문 상세 목록
-
-    //주문 생성 시 기본 값을 PAYMENT_PENDING으로 설정
-    @PrePersist
-    public void prePersist() {
-        this.orderStatus = OrderStatus.PAYMENT_PENDING;
-    }
-
-    public void updateStatus(OrderStatus newStatus) {
-        this.orderStatus = newStatus;
-    }
 
 }

--- a/src/main/java/com/korit/pawsmarket/domain/order/entity/repository/OrderRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/entity/repository/OrderRepository.java
@@ -1,0 +1,10 @@
+package com.korit.pawsmarket.domain.order.entity.repository;
+
+import com.korit.pawsmarket.domain.order.entity.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepository extends JpaRepository <Order, Long> {
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/order/facade/OrderFacade.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/facade/OrderFacade.java
@@ -1,0 +1,74 @@
+package com.korit.pawsmarket.domain.order.facade;
+
+import com.korit.pawsmarket.domain.OrderDetail.dto.req.CreateOrderDetailReqDto;
+import com.korit.pawsmarket.domain.OrderDetail.dto.resp.CreateOrderDetailRespDto;
+import com.korit.pawsmarket.domain.OrderDetail.entity.OrderDetail;
+import com.korit.pawsmarket.domain.OrderDetail.facde.OrderDetailFacade;
+import com.korit.pawsmarket.domain.order.dto.req.CreateOrderReqDto;
+import com.korit.pawsmarket.domain.order.entity.Order;
+import com.korit.pawsmarket.domain.order.service.CreateOrderService;
+import com.korit.pawsmarket.domain.product.entity.Product;
+import com.korit.pawsmarket.domain.product.entity.repository.ProductRepository;
+import com.korit.pawsmarket.domain.user.entity.User;
+import com.korit.pawsmarket.domain.user.entity.repository.UserRepository;
+import com.korit.pawsmarket.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Transactional
+@Component
+@RequiredArgsConstructor
+public class OrderFacade {
+
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+    private final CreateOrderService createOrderService;
+    private final OrderDetailFacade orderDetailFacade;
+
+    public Order createOrder(CreateOrderReqDto req) {
+
+        //1. 유저 조회
+        User user = userRepository.findById(req.userId())
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 유저 입니다."));
+
+        //2. 주문 객체 생성
+        Order order = req.toEntity(user);
+
+        //3. 주문 상품 조회 (상품 정보가 db에 있는지 확인)
+        List<Long> productIds = req.orderDetails().stream()
+                .map(CreateOrderDetailReqDto -> CreateOrderDetailReqDto.productId())
+                .toList();
+        List<Product> products = productRepository.findByProductIds(productIds);
+
+        if (products.size() != productIds.size()) {
+            throw new NotFoundException("존재하지 않는 상품이 있습니다.");
+        }
+
+        //4. 주문 상세 리스트 생성
+        List<CreateOrderDetailRespDto> orderDetails = req.orderDetails().stream()
+                .map(createOrderDetailReqDto -> {
+                    Product product = products.stream()
+                            .filter(p -> p.getProductId().equals(createOrderDetailReqDto.productId()))
+                            .findFirst()
+                            .orElseThrow(() -> new NotFoundException("해당 상품이 존재하지 않습니다. 상품 ID: " + createOrderDetailReqDto.productId()));
+
+                    OrderDetail orderDetail = orderDetailFacade.createOrderDetail(order, product, createOrderDetailReqDto.quantity());
+
+                    return CreateOrderDetailRespDto.from(orderDetail);
+                })
+                .toList();
+
+        //6. 주문 저장
+        createOrderService.createOrder(order);
+
+        //7.주문 상세 저장
+        return order;
+
+    }
+
+}

--- a/src/main/java/com/korit/pawsmarket/domain/order/service/CreateOrderService.java
+++ b/src/main/java/com/korit/pawsmarket/domain/order/service/CreateOrderService.java
@@ -1,0 +1,15 @@
+package com.korit.pawsmarket.domain.order.service;
+
+import com.korit.pawsmarket.domain.order.entity.Order;
+import com.korit.pawsmarket.domain.order.entity.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CreateOrderService {
+
+    private final OrderRepository orderRepository;
+
+    public void createOrder(Order order) { orderRepository.save(order); }
+}

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/Product.java
@@ -60,4 +60,14 @@ public class Product extends BaseEntity {
 
     @Column(name = "discount_rate")
     private int discountRate;               // 할인율
+
+    public void decreaseStock(int quantity) {
+        if(this.stock < quantity) {
+            throw new IllegalArgumentException("재고 부족: 현재 재고 " + this.stock + ", 요청 수량 " + quantity);
+        }
+        this.stock -= quantity; // 재고 감소
+        this.salesQuantity += quantity; // 판매 수량 증가
+    }
+
 }
+

--- a/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
+++ b/src/main/java/com/korit/pawsmarket/domain/product/entity/repository/ProductRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -22,4 +23,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT p FROM Product p WHERE p.isDelete = false AND p.productId = :productId")
     Optional<Product> findByIdQuery(@Param("productId") Long productId);
+
+    @Query("SELECT p FROM Product p WHERE p.productId IN :productIds")
+    List<Product> findByProductIds(@Param("productIds") List<Long> productIds);
 }

--- a/src/main/java/com/korit/pawsmarket/domain/user/entity/User.java
+++ b/src/main/java/com/korit/pawsmarket/domain/user/entity/User.java
@@ -36,6 +36,9 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private LocalDate birth;
 
+    @Column(nullable = false)
+    private String phone;
+
     @Column(nullable = true)
     private String profileImg;
 

--- a/src/main/java/com/korit/pawsmarket/web/api/user/req/UserCreateReqDto.java
+++ b/src/main/java/com/korit/pawsmarket/web/api/user/req/UserCreateReqDto.java
@@ -35,6 +35,10 @@ public record UserCreateReqDto(
         @NotBlank(message = "주소는 필수 입력입니다.")
         String address,
 
+        @Schema(example = "010-1234-5678")
+        @NotBlank(message = "전화번호는 필수 입력입니다.")
+        String phone,
+
         @Schema(example = "1997-03-29")
         @NotNull(message = "생년월일은 필수 입력입니다.")
         LocalDate birth,
@@ -56,6 +60,7 @@ public record UserCreateReqDto(
                      .password(dto.authProvider == AuthProvider.COMMON ? encodedPassword : null) //Oauth 회원은 비번 없음
                      .nick(dto.nick)
                      .address(dto.address)
+                     .phone(dto.phone)
                      .birth(dto.birth)
                      .profileImg(dto.profileImg)
                      .role(role)


### PR DESCRIPTION
## 📝 설명 (Description)  
주문 생성(Order Creation) 및 주문 상세(OrderDetail) 생성 과정에서 데이터 일관성을 확보하고 예외 처리를 개선하기 위해 OrderFacade 및 OrderDetailFacade를 도입하였습니다.  
또한, 주문 요청 DTO와 응답 DTO를 정리하여 데이터 전달을 명확하게 하였습니다.  

---

## 🔄 변경 사항 (Changes)  
이번 PR에서 수행된 변경 사항들은 다음과 같습니다:  
- [x] **OrderFacade 도입**  
  - `createOrder(CreateOrderReqDto req)` 메서드를 통해 주문 생성 및 검증을 수행  
  - User, Product 조회 후 주문(Order) 및 주문 상세(OrderDetail) 객체 생성  
  - `@Transactional` 적용으로 트랜잭션 관리 강화  
- [x] **OrderDetailFacade 도입**  
  - `createOrderDetail(Order order, Product product, int quantity)` 메서드를 통해 주문 상세 생성 및 재고 차감 로직 구현  
  - 재고 부족 시 `IllegalArgumentException` 예외 발생 및 로깅 추가  
  - 할인율을 고려한 최종 가격 계산 로직 추가  
- [x] **예외 처리 개선**  
  - 존재하지 않는 `User` 또는 `Product` 조회 시 `NotFoundException` 발생  
  - 주문 상세 생성 시 존재하지 않는 `Product` 조회 시 예외 발생  
- [x] **DTO 구조 개선**  
  - `CreateOrderDetailReqDto` 및 `CreateOrderDetailRespDto` 추가하여 요청 및 응답 구조 정리  
  - `from(OrderDetail orderDetail)` 메서드 추가하여 Entity → DTO 변환 로직 적용  

---

## 📌 참고 사항 (Additional Notes)  
- 기존의 `OrderService` 내에서 수행되던 주문 생성 로직을 `OrderFacade`로 분리하여 관심사 분리를 수행함  
- 주문 생성 시 예외 발생 시 전체 트랜잭션이 롤백되도록 `@Transactional` 적용  
- 주문 상세 생성 시 할인율을 적용한 가격 계산 로직 추가  
